### PR TITLE
Add pinnableslice unit tests

### DIFF
--- a/tests/c/test_pinnableslice.py
+++ b/tests/c/test_pinnableslice.py
@@ -1,0 +1,26 @@
+import pytest
+
+from zeroae.rocksdb.c import db as rdb
+from zeroae.rocksdb.c import pinnableslice
+
+
+@pytest.fixture
+def db(rocksdb_db, rocksdb_writeoptions):
+    rdb.put(rocksdb_db, rocksdb_writeoptions, "key", "value")
+    yield rocksdb_db
+
+
+@pytest.fixture
+def slice(db, rocksdb_readoptions):
+    rv = rdb.get_pinned(db, rocksdb_readoptions, "key")
+    yield rv
+    pinnableslice.destroy(rv)
+
+
+def test_fixture(slice):
+    assert slice is not None
+
+
+def test_value(slice):
+    rv = pinnableslice.value(slice)
+    assert rv == "value"

--- a/zeroae/rocksdb/c/pinnableslice.i
+++ b/zeroae/rocksdb/c/pinnableslice.i
@@ -3,4 +3,8 @@ ROCKSDB_MODULE_HEADER(pinnableslice, package="zeroae.rocksdb.c")
 
 %delobject destroy;
 
+%cstring_output_allocate_size_keep_null(const char **rv, size_t* rvlen,);
+%wrap_rv(value, (rocksdb_pinnableslice_t* t, const char** rv, size_t* rvlen),
+         rocksdb_pinnableslice_value, (t, rvlen))
+
 ROCKSDB_MODULE_FOOTER()


### PR DESCRIPTION
Ideally the Pinnable slice should not allocate more memory. 

We need to investigate how Python + SWIG can point directly to that memory space without reallocating a string.

Close #69