### PR TITLE
Add tests for sstfilewriter

### DIFF
--- a/tests/c/conftest.py
+++ b/tests/c/conftest.py
@@ -161,8 +161,13 @@ def rocksdb_restore_options():
     restore_options.destroy(rv)
 
 
+@pytest.fixture()
+def rocksdb_sstfilewriter_file(tmp_path_factory):
+    return str(tmp_path_factory.mktemp("sstfw", numbered=1)/"file.sst")
+
+
 @pytest.fixture
-def rocksdb_sstfilewriter(rocksdb_envoptions, rocksdb_options):
+def rocksdb_sstfilewriter(rocksdb_envoptions, rocksdb_options, rocksdb_sstfilewriter_file):
     rv = sstfilewriter.create(rocksdb_envoptions, rocksdb_options)
     yield rv
     sstfilewriter.destroy(rv)

--- a/tests/c/test_sstfilewriter.py
+++ b/tests/c/test_sstfilewriter.py
@@ -1,47 +1,47 @@
 import pytest
 
-from zeroae.rocksdb.c import sstfilewriter
+from zeroae.rocksdb.c import sstfilewriter as sstfw
+
+@pytest.fixture
+def sstfw_f(rocksdb_sstfilewriter, rocksdb_sstfilewriter_file):
+    sstfw.open(rocksdb_sstfilewriter, rocksdb_sstfilewriter_file)
+    yield rocksdb_sstfilewriter
+    sstfw.finish(rocksdb_sstfilewriter)
 
 
 def test_fixture(rocksdb_sstfilewriter):
-    assert rocksdb_sstfilewriter is not None
+    assert sstfw_f is not None
+
 
 @pytest.mark.xfail
 def test_create_with_comparator(rocksdb_envoptions, rocksdb_options):
     assert False
 
 
-@pytest.mark.xfail
-def test_open():
+def test_add(sstfw_f):
+    sstfw.add(sstfw_f, "key0", "val")
+    sstfw.add(sstfw_f, "key1", "val")
+
+
+def test_put(sstfw_f):
+    sstfw.put(sstfw_f, "key", "val")
+
+
+@pytest.mark.skip
+def test_merge(sstfw_f):
     assert False
 
 
-@pytest.mark.xfail
-def test_add():
-    assert False
+def test_delete(sstfw_f):
+    sstfw.add(sstfw_f, "key0", "val")
+    sstfw.delete(sstfw_f, "key1")
 
 
-@pytest.mark.xfail
-def test_put():
-    assert False
+def test_file_size(rocksdb_sstfilewriter, rocksdb_sstfilewriter_file):
+    assert sstfw.file_size(rocksdb_sstfilewriter) == 0
 
+    sstfw.open(rocksdb_sstfilewriter, rocksdb_sstfilewriter_file)
+    sstfw.add(rocksdb_sstfilewriter, "key", "val")
+    sstfw.finish(rocksdb_sstfilewriter)
 
-@pytest.mark.xfail
-def test_merge():
-    assert False
-
-
-@pytest.mark.xfail
-def test_delete():
-    assert False
-
-
-@pytest.mark.xfail
-def test_finish():
-    assert False
-
-
-@pytest.mark.xfail
-def test_file_size():
-    assert False
-
+    assert sstfw.file_size(rocksdb_sstfilewriter) == pytest.approx(821, 8)

--- a/zeroae/rocksdb/c/sstfilewriter.i
+++ b/zeroae/rocksdb/c/sstfilewriter.i
@@ -5,9 +5,8 @@ ROCKSDB_MODULE_HEADER(sstfilewriter, package="zeroae.rocksdb.c")
 %newobject create_with_comparator;
 %delobject destroy;
 
-%apply (const char *STRING, size_t LENGTH) {
-    (const char* key, size_t keylen),
-    (const char* val, size_t vallen)
-}
+%cstring_input_binary(const char* key, size_t keylen);
+%cstring_input_binary(const char* val, size_t vallen);
+%apply (uint64_t *OUTPUT) { uint64_t* file_size }
 
 ROCKSDB_MODULE_FOOTER()


### PR DESCRIPTION
We need to wait for `comparator_t` and `merge_operator_t` 
to remove all the xfails.

Close #55